### PR TITLE
Fix UTF-8 handling in EventSource parser

### DIFF
--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -111,8 +111,8 @@ public actor EventSource {
         /// Convert the line buffer to a string and clear it
         private func processLineBuffer() -> String {
             // Skip UTF-8 BOM if present at the start of the buffer
-            if lineBuffer.count >= 3 && lineBuffer[0] == 0xEF && lineBuffer[1] == 0xBB
-                && lineBuffer[2] == 0xBF
+            if lineBuffer.count >= 3,
+                lineBuffer.prefix(3) == [0xEF, 0xBB, 0xBF]
             {
                 lineBuffer.removeFirst(3)
             }

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -110,7 +110,15 @@ public actor EventSource {
 
         /// Convert the line buffer to a string and clear it
         private func processLineBuffer() -> String {
-            let line = String(bytes: lineBuffer, encoding: .utf8) ?? ""
+            // Skip UTF-8 BOM if present at the start of the buffer
+            if lineBuffer.count >= 3 && lineBuffer[0] == 0xEF && lineBuffer[1] == 0xBB
+                && lineBuffer[2] == 0xBF
+            {
+                lineBuffer.removeFirst(3)
+            }
+
+            // Use String(decoding:as:) to handle invalid UTF-8 sequences by replacing them with replacement character
+            let line = String(decoding: lineBuffer, as: UTF8.self)
             lineBuffer.removeAll(keepingCapacity: true)
             return line
         }

--- a/Tests/EventSourceTests/ParserTests.swift
+++ b/Tests/EventSourceTests/ParserTests.swift
@@ -2,196 +2,184 @@ import Testing
 
 @testable import EventSource
 
-@Suite("Parser Tests", .timeLimit(.minutes(1)))
+@Suite("EventSource Parser Tests", .timeLimit(.minutes(1)))
 struct ParserTests {
-    @Test("Basic event parsing")
-    func testSimpleEvent() async throws {
-        let parser = EventSource.Parser()
-        // Test a simple event with data
-        let bytes = "data: hello\n\n".utf8
-        for byte in bytes {
-            await parser.consume(byte)
-        }
-        await parser.finish()
-
-        let event = await parser.getNextEvent()
-        #expect(event != nil)
-        #expect(event?.data == "hello")
-        #expect(event?.id == nil)
-        #expect(event?.event == nil)
-        #expect(event?.retry == nil)
+    @Test("Empty stream produces no events")
+    func testEmptyStreamProducesNoEvents() async {
+        let events = await getEvents(from: "")
+        #expect(events.isEmpty)
     }
 
-    @Test("Event with all fields")
-    func testEventWithAllFields() async throws {
-        let parser = EventSource.Parser()
-        // Test an event with all possible fields
-        let bytes = """
-            id: 123
-            event: test
-            data: hello
-            retry: 5000
-
-            """.utf8
-
-        for byte in bytes {
-            await parser.consume(byte)
-        }
-        await parser.finish()
-
-        let event = await parser.getNextEvent()
-        #expect(event != nil)
-        #expect(event?.id == "123")
-        #expect(event?.event == "test")
-        #expect(event?.data == "hello")
-        #expect(event?.retry == 5000)
+    @Test("Comment only stream produces no events")
+    func testCommentOnlyStreamProducesNoEvents() async {
+        let stream = ":comment line 1\n:comment line 2\r\n"
+        let events = await getEvents(from: stream)
+        #expect(events.isEmpty)
     }
 
-    @Suite("Line Break Handling")
-    struct LineBreakTests {
-        @Test("CRLF line breaks")
-        func testCRLFLineBreaks() async throws {
-            let parser = EventSource.Parser()
-            let bytes = "data: hello\r\n\r\n".utf8
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.data == "hello")
+    @Suite("Single Line Event Tests")
+    struct SingleLineEventTests {
+        @Test("LF line breaks")
+        func testSingleLineEventLF() async {
+            let stream = "data: test data\n\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.data == "test data")
+            #expect(events.first?.id == nil)
+            #expect(events.first?.event == nil)
         }
 
         @Test("CR line breaks")
-        func testCRLineBreaks() async throws {
-            let parser = EventSource.Parser()
-            let bytes = "data: hello\r\r".utf8
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.data == "hello")
+        func testSingleLineEventCR() async {
+            let stream = "data: test data\r\r"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.data == "test data")
         }
 
-        @Test("LF line breaks")
-        func testLFLineBreaks() async throws {
-            let parser = EventSource.Parser()
-            let bytes = "data: hello\n\n".utf8
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.data == "hello")
+        @Test("CRLF line breaks")
+        func testSingleLineEventCRLF() async {
+            let stream = "data: test data\r\n\r\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.data == "test data")
         }
     }
 
-    @Suite("Multiple Events")
-    struct MultipleEventsTests {
-        @Test("Sequential events")
-        func testMultipleEvents() async throws {
-            let parser = EventSource.Parser()
-            let bytes = """
-                data: event1
-
-                data: event2
-
-                """.utf8
-
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event1 = await parser.getNextEvent()
-            #expect(event1 != nil)
-            #expect(event1?.data == "event1")
-
-            let event2 = await parser.getNextEvent()
-            #expect(event2 != nil)
-            #expect(event2?.data == "event2")
-
-            let event3 = await parser.getNextEvent()
-            #expect(event3 == nil)
-        }
+    @Test("Multi-line data")
+    func testMultiLineData() async {
+        let stream = "data: line1\ndata: line2\n\n"
+        let events = await getEvents(from: stream)
+        #expect(events.count == 1)
+        #expect(events.first?.data == "line1\nline2")
     }
 
-    @Suite("Data Field Tests")
-    struct DataFieldTests {
-        @Test("Multi-line data")
-        func testMultiLineData() async throws {
+    @Suite("Event Field Tests")
+    struct EventFieldTests {
+        @Test("Event with ID")
+        func testEventWithID() async {
+            let stream = "id: 123\ndata: test data\n\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.id == "123")
+            #expect(events.first?.data == "test data")
             let parser = EventSource.Parser()
-            let bytes = """
-                data: line1
-                data: line2
-
-                """.utf8
-
-            for byte in bytes {
+            for byte in "id: 123\n".utf8 {
                 await parser.consume(byte)
             }
-
-            // Force completion to ensure all data is processed
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.data == "line1\nline2")
+            #expect(await parser.getLastEventId() == "123")
         }
 
-        @Test("Empty data")
-        func testEmptyData() async throws {
+        @Test("Event with NUL in ID is ignored")
+        func testEventWithNULInIDIsIgnoredAndDoesNotSetLastEventID() async {
+            let stream = "id: abc\0def\ndata: test\n\n"  // ID with NUL
             let parser = EventSource.Parser()
-            let bytes = "data:\n\n".utf8
-            for byte in bytes {
+
+            // Consume the stream
+            for byte in stream.utf8 {
                 await parser.consume(byte)
             }
             await parser.finish()
 
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.data == "")
+            // Check that lastEventId was not updated with the NUL-containing ID
+            #expect(
+                await parser.getLastEventId() == "",
+                "LastEventId should not be set to a value containing NUL.")
+
+            // Check the dispatched event
+            var dispatchedEvents: [EventSource.Event] = []
+            while let event = await parser.getNextEvent() {
+                dispatchedEvents.append(event)
+            }
+
+            #expect(dispatchedEvents.count == 1)
+            #expect(
+                dispatchedEvents.first?.id == nil,
+                "Event's ID field should be nil because the raw ID field contained NUL.")
+            #expect(dispatchedEvents.first?.data == "test")
         }
-    }
 
-    @Suite("Comment Tests")
-    struct CommentTests {
-        @Test("Comment handling")
-        func testComments() async throws {
+        @Test("ID reset by empty ID line")
+        func testIDResetByEmptyIDLine() async {
+            let stream = "id: 123\ndata: event1\n\nid: \ndata: event2\n\n"
             let parser = EventSource.Parser()
-            let bytes = """
-                :comment
-                data: hello
-                :another comment
 
-                """.utf8
-
-            for byte in bytes {
+            for byte in stream.utf8 {
                 await parser.consume(byte)
             }
             await parser.finish()
 
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.data == "hello")
+            var events: [EventSource.Event] = []
+            while let event = await parser.getNextEvent() {
+                events.append(event)
+            }
+
+            #expect(events.count == 2)
+            #expect(events[0].id == "123", "First event should have id '123'")
+            #expect(events[0].data == "event1")
+
+            // After "id: " line, lastEventId should be reset to empty string
+            #expect(
+                await parser.getLastEventId() == "",
+                "lastEventID should be reset to empty string by an 'id:' line.")
+
+            #expect(
+                events[1].id == "",  // Changed from nil to empty string
+                "Second event's currentEventId should be empty string as 'id:' resets it.")
+            #expect(events[1].data == "event2")
         }
 
-        @Test("Only comments")
-        func testOnlyComments() async throws {
+        @Test("Event with name")
+        func testEventWithName() async {
+            let stream = "event: custom\ndata: test data\n\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.event == "custom")
+            #expect(events.first?.data == "test data")
+        }
+
+        @Test("Retry field")
+        func testRetryField() async {
+            let stream = "retry: 5000\ndata: test data\n\n"
             let parser = EventSource.Parser()
-            let bytes = """
-                :comment line 1
-                :comment line 2
-                :comment line 3
+            // Manually consume and finish to inspect parser state before getting all events
+            for byte in stream.utf8 {
+                await parser.consume(byte)
+            }
+            await parser.finish()
 
-                """.utf8
+            // Check reconnection time on parser
+            #expect(await parser.getReconnectionTime() == 5000)
 
+            var events: [EventSource.Event] = []
+            while let event = await parser.getNextEvent() { events.append(event) }
+
+            #expect(events.count == 1)
+            #expect(events.first?.data == "test data")
+            #expect(
+                events.first?.retry == 5000,
+                "The retry value should be part of the event if dispatched with it.")
+        }
+
+        @Test("Retry field only updates reconnection time")
+        func testRetryFieldOnlyUpdatesReconnectionTimeDoesNotDispatchEvent() async {
+            let stream = "retry: 1234\n\n"  // Only retry, no data or other fields
+            let parser = EventSource.Parser()
+            let initialReconnectionTime = await parser.getReconnectionTime()
+
+            let events = await getEvents(from: stream, parser: parser)
+
+            #expect(
+                events.isEmpty,
+                "A message containing only a 'retry' field should not produce an event.")
+            #expect(await parser.getReconnectionTime() == 1234)
+            #expect(initialReconnectionTime != 1234)
+        }
+
+        @Test("Invalid retry value")
+        func testInvalidRetryField() async {
+            let parser = EventSource.Parser()
+            let bytes = "retry: invalid\n\n".utf8
             for byte in bytes {
                 await parser.consume(byte)
             }
@@ -199,10 +187,184 @@ struct ParserTests {
 
             let event = await parser.getNextEvent()
             #expect(event == nil)
+            #expect(await parser.getReconnectionTime() == 3000)  // Default value
+        }
+    }
+
+    @Test("Multiple events")
+    func testMultipleEvents() async {
+        let stream = "data: event1\n\nevent: custom\ndata: event2\nid: e2\n\n"
+        let events = await getEvents(from: stream)
+        #expect(events.count == 2)
+
+        #expect(events[0].data == "event1")
+        #expect(events[0].event == nil)
+        #expect(events[0].id == nil)
+
+        #expect(events[1].data == "event2")
+        #expect(events[1].event == "custom")
+        #expect(events[1].id == "e2")
+    }
+
+    @Test("Mixed line endings produce correct events")
+    func testMixedLineEndingsProduceCorrectEvents() async {
+        let stream =
+            "data: event1\r\r" + "data: event2\n\n" + "data: event3\r\n\r\n"
+            + "id: e4\rdata: event4\r\r"  // `id: e4` is one line, `data: event4` is next, then dispatch
+            + "event: custom\ndata: event5\n\n"
+
+        let events = await getEvents(from: stream)
+        #expect(events.count == 5)
+        #expect(events[0].data == "event1")
+        #expect(events[1].data == "event2")
+        #expect(events[2].data == "event3")
+        #expect(events[3].id == "e4")
+        #expect(events[3].data == "event4")
+        #expect(events[4].event == "custom")
+        #expect(events[4].data == "event5")
+    }
+
+    @Suite("Field Parsing Tests")
+    struct FieldParsingTests {
+        @Test("Colon space parsing")
+        func testColonSpaceParsing() async {
+            // Case 1: "data:value"
+            let stream1 = "data:value1\n\n"
+            let events1 = await getEvents(from: stream1)
+            #expect(events1.count == 1)
+            #expect(events1.first?.data == "value1")
+
+            // Case 2: "data: value" (single leading space after colon)
+            let stream2 = "data: value2\n\n"
+            let events2 = await getEvents(from: stream2)
+            #expect(events2.count == 1)
+            #expect(events2.first?.data == "value2")
+
+            // Case 3: "data:  value" (multiple leading spaces after colon)
+            let stream3 = "data:  value3\n\n"
+            let events3 = await getEvents(from: stream3)
+            #expect(events3.count == 1)
+            #expect(events3.first?.data == " value3", "Only one leading space should be trimmed.")
+        }
+
+        @Test("Unicode in data")
+        func testUnicodeInData() async {
+            let unicodeData = "¯\\_(ツ)_/¯0️⃣🇺🇸Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮𝓯𝓸𝔁✅"
+            let stream = "data: \(unicodeData)\n\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.data == unicodeData)
+        }
+
+        @Test("NUL character in data")
+        func testNULCharacterInData() async {
+            let dataWithNul = "hello\0world"
+            let stream = "data: \(dataWithNul)\n\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1)
+            #expect(events.first?.data == dataWithNul)
+        }
+
+        @Test("Invalid UTF8 sequence becomes replacement character")
+        func testInvalidUTF8SequenceBecomesReplacementCharacter() async {
+            // Create a byte array with an invalid UTF-8 sequence
+            var invalidBytesStream: [UInt8] = []
+            // Add "data: test" as raw bytes
+            invalidBytesStream.append(contentsOf: [
+                0x64, 0x61, 0x74, 0x61, 0x3A, 0x20, 0x74, 0x65, 0x73, 0x74,
+            ])
+            invalidBytesStream.append(0xFF)  // Invalid UTF-8 byte
+            // Add "string" as raw bytes
+            invalidBytesStream.append(contentsOf: [0x73, 0x74, 0x72, 0x69, 0x6E, 0x67])
+            // Add newlines
+            invalidBytesStream.append(contentsOf: [0x0A, 0x0A])
+
+            let parser = EventSource.Parser()
+            // Process each byte individually
+            for byte in invalidBytesStream {
+                await parser.consume(byte)
+            }
+            await parser.finish()
+
+            var events: [EventSource.Event] = []
+            while let event = await parser.getNextEvent() {
+                events.append(event)
+            }
+
+            #expect(events.count == 1)
+            #expect(
+                events.first?.data == "test\u{FFFD}string",
+                "Invalid UTF-8 byte should be replaced by replacement character.")
+        }
+    }
+
+    @Suite("Empty Field Tests")
+    struct EmptyFieldTests {
+        @Test("Empty data field dispatch")
+        func testEmptyDataFieldDispatch() async {
+            // An event with a "data" field that results in empty string data should still be dispatched.
+            // "data" (field name with empty value)
+            let stream1 = "data\n\n"
+            let events1 = await getEvents(from: stream1)
+            #expect(events1.count == 1, "Event should be dispatched for 'data' field.")
+            #expect(events1.first?.data == "", "Data should be empty string.")
+
+            // "data:" (field name with explicit empty value)
+            let stream2 = "data:\n\n"
+            let events2 = await getEvents(from: stream2)
+            #expect(events2.count == 1, "Event should be dispatched for 'data:' field.")
+            #expect(events2.first?.data == "", "Data should be empty string.")
+        }
+
+        @Test("Fields without value are processed correctly")
+        func testFieldsWithoutValueAreProcessedCorrectly() async {
+            // According to spec:
+            // - "event" (no value): event type set to empty string.
+            // - "data" (no value): data buffer gets an empty string.
+            // - "id" (no value): last event ID set to empty string. (currentEventId for dispatch is empty string)
+            // - "retry" (no value or invalid): ignored.
+            let stream = "event\ndata\nid\nretry\n\n"
+            let parser = EventSource.Parser()
+            let initialReconnectTime = await parser.getReconnectionTime()
+
+            let events = await getEvents(from: stream, parser: parser)
+            #expect(events.count == 1)
+            #expect(events.first?.data == "", "Data from 'data' line without value.")
+            #expect(events.first?.event == "", "Event type from 'event' line without value.")
+            #expect(
+                events.first?.id == "",  // Changed from nil to empty string
+                "currentEventId should be empty string as 'id' line had no value.")
+            #expect(
+                await parser.getLastEventId() == "",
+                "LastEventId should be empty string from 'id' line without value.")
+            #expect(
+                await parser.getReconnectionTime() == initialReconnectTime,
+                "Empty 'retry' field should not change reconnection time.")
+        }
+    }
+
+    @Suite("Comment and Line Tests")
+    struct CommentAndLineTests {
+        @Test("Only comment lines and empty lines produce no events")
+        func testOnlyCommentLinesAndEmptyLinesProduceNoEvents() async {
+            let stream = ":comment\n\n:another comment\r\n\r\n"  // Includes dispatch-triggering empty lines but no data fields
+            let events = await getEvents(from: stream)
+            #expect(
+                events.isEmpty,
+                "Stream with only comments and blank lines should produce no events if no data fields were processed."
+            )
+        }
+
+        @Test("Line without colon is ignored")
+        func testLineWithoutColonIsIgnored() async {
+            let stream = "this is a bogus line\ndata: valid\n\nthis is also bogus\r\n"
+            let events = await getEvents(from: stream)
+            #expect(events.count == 1, "Only one event from the valid 'data: valid' line.")
+            #expect(events.first?.data == "valid")
         }
 
         @Test("Complex mixed comments and events")
-        func testMixedCommentsAndEvents() async throws {
+        func testMixedCommentsAndEvents() async {
             let parser = EventSource.Parser()
             let bytes = """
                 :initial comment
@@ -238,113 +400,99 @@ struct ParserTests {
             let event3 = await parser.getNextEvent()
             #expect(event3 == nil)
         }
-    }
 
-    @Suite("Retry Field Tests")
-    struct RetryFieldTests {
-        @Test("Valid retry value")
-        func testRetryField() async throws {
-            let parser = EventSource.Parser()
-            let bytes = "retry: 1000\n\n".utf8
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
+        @Test("Final line unterminated is processed by finish")
+        func testFinalLineUnterminatedIsProcessedByCurrentFinishLogic() async {
+            // This test reflects the current behavior of Parser.finish().
+            // As noted, the SSE spec suggests an unterminated final block without a blank line should be discarded.
+            // Your parser's finish() method currently dispatches such events.
+            let stream = "data: final event"  // No trailing newline or blank line
+            let events = await getEvents(from: stream)
+            #expect(
+                events.count == 1, "Event should be dispatched based on current finish() logic.")
+            #expect(events.first?.data == "final event")
 
-            // A "retry" field alone should not dispatch an event object.
-            let event = await parser.getNextEvent()
-            #expect(event == nil)
-            // It should, however, update the internal reconnection time.
-            #expect(await parser.getReconnectionTime() == 1000)
-        }
-
-        @Test("Invalid retry value")
-        func testInvalidRetryField() async throws {
-            let parser = EventSource.Parser()
-            let bytes = "retry: invalid\n\n".utf8
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event == nil)
-            #expect(await parser.getReconnectionTime() == 3000)  // Default value
+            let streamWithID = "id: lastid\ndata: final event with id"
+            let events2 = await getEvents(from: streamWithID)
+            #expect(events2.count == 1)
+            #expect(events2.first?.id == "lastid")
+            #expect(events2.first?.data == "final event with id")
         }
     }
 
-    @Suite("Last Event ID Tests")
-    struct LastEventIDTests {
-        @Test("Setting last event ID")
-        func testLastEventID() async throws {
+    @Suite("BOM Tests")
+    struct BOMTests {
+        @Test("UTF8 BOM at stream start is handled")
+        func testUtf8BOMAtStreamStartIsHandled() async {
+            // Create a byte array with UTF-8 BOM followed by SSE content
+            var fullStreamBytes: [UInt8] = []
+            // Add UTF-8 BOM
+            fullStreamBytes.append(contentsOf: [0xEF, 0xBB, 0xBF])
+            // Add SSE message
+            fullStreamBytes.append(
+                contentsOf: createSSEMessage(fields: [
+                    (name: "data", value: "test with bom")
+                ]))
+
             let parser = EventSource.Parser()
-            let bytes = """
-                id: 123
-                data: hello
-
-                """.utf8
-
-            for byte in bytes {
+            // Process each byte individually
+            for byte in fullStreamBytes {
                 await parser.consume(byte)
             }
             await parser.finish()
 
-            _ = await parser.getNextEvent()
-            #expect(await parser.getLastEventId() == "123")
-        }
-
-        @Test("Empty event ID")
-        func testEmptyEventID() async throws {
-            let parser = EventSource.Parser()
-            let bytes = """
-                id:
-                data: hello
-
-                """.utf8
-
-            for byte in bytes {
-                await parser.consume(byte)
+            var events: [EventSource.Event] = []
+            while let event = await parser.getNextEvent() {
+                events.append(event)
             }
-            await parser.finish()
 
-            _ = await parser.getNextEvent()
-            #expect(await parser.getLastEventId() == "")
+            #expect(events.count == 1, "One event should be parsed.")
+            #expect(
+                events.first?.data == "test with bom",
+                "Data should be correct, implying BOM was handled by UTF-8 decoding before field parsing."
+            )
         }
     }
+}
 
-    @Suite("Event Type Tests")
-    struct EventTypeTests {
-        @Test("Default event type")
-        func testDefaultEventType() async throws {
-            let parser = EventSource.Parser()
-            let bytes = "data: hello\n\n".utf8
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.event == nil)  // Should be nil for default "message" type
-        }
-
-        @Test("Custom event type")
-        func testCustomEventType() async throws {
-            let parser = EventSource.Parser()
-            let bytes = """
-                event: custom
-                data: hello
-
-                """.utf8
-
-            for byte in bytes {
-                await parser.consume(byte)
-            }
-            await parser.finish()
-
-            let event = await parser.getNextEvent()
-            #expect(event != nil)
-            #expect(event?.event == "custom")
-        }
+// Helper to consume a string and get all dispatched events
+private func getEvents(
+    from input: String, parser: EventSource.Parser = EventSource.Parser()
+)
+    async -> [EventSource.Event]
+{
+    for byte in input.utf8 {
+        await parser.consume(byte)
     }
+    // Call finish to process any buffered line and dispatch pending event based on current parser logic.
+    // Note: Spec interpretation for final unterminated lines is discussed in test_finalLineUnterminatedIsProcessedByFinish.
+    await parser.finish()
+    var events: [EventSource.Event] = []
+    while let event = await parser.getNextEvent() {
+        events.append(event)
+    }
+    return events
+}
+
+// Helper function to create a properly formatted SSE field
+private func createSSEField(name: String, value: String) -> [UInt8] {
+    var bytes: [UInt8] = []
+    // Add field name and colon
+    bytes.append(contentsOf: name.utf8)
+    bytes.append(0x3A)  // colon
+    bytes.append(0x20)  // space
+    // Add field value
+    bytes.append(contentsOf: value.utf8)
+    return bytes
+}
+
+// Helper function to create a complete SSE message
+private func createSSEMessage(fields: [(name: String, value: String)]) -> [UInt8] {
+    var bytes: [UInt8] = []
+    for field in fields {
+        bytes.append(contentsOf: createSSEField(name: field.name, value: field.value))
+        bytes.append(0x0A)  // newline
+    }
+    bytes.append(0x0A)  // final newline to end the message
+    return bytes
 }

--- a/Tests/EventSourceTests/ParserTests.swift
+++ b/Tests/EventSourceTests/ParserTests.swift
@@ -249,6 +249,7 @@ struct ParserTests {
 
         @Test("Unicode in data")
         func testUnicodeInData() async {
+            // Adapted from https://github.com/launchdarkly/swift-eventsource/blob/193c097f324666691f71b49b1e70249ef21f9f62/Tests/UTF8LineParserTests.swift#L59
             let unicodeData = "¯\\_(ツ)_/¯0️⃣🇺🇸Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮𝓯𝓸𝔁✅"
             let stream = "data: \(unicodeData)\n\n"
             let events = await getEvents(from: stream)
@@ -457,7 +458,8 @@ struct ParserTests {
 
 // Helper to consume a string and get all dispatched events
 private func getEvents(
-    from input: String, parser: EventSource.Parser = EventSource.Parser()
+    from input: String,
+    parser: EventSource.Parser = EventSource.Parser()
 )
     async -> [EventSource.Event]
 {
@@ -465,7 +467,6 @@ private func getEvents(
         await parser.consume(byte)
     }
     // Call finish to process any buffered line and dispatch pending event based on current parser logic.
-    // Note: Spec interpretation for final unterminated lines is discussed in test_finalLineUnterminatedIsProcessedByFinish.
     await parser.finish()
     var events: [EventSource.Event] = []
     while let event = await parser.getNextEvent() {


### PR DESCRIPTION
This PR improves UTF-8 handling in the EventSource parser, specifically:

1. Invalid UTF-8 sequences are now properly handled by replacing them with the replacement character (U+FFFD) instead of failing to decode the line
2. UTF-8 BOM (Byte Order Mark) markers at the start of the stream are now properly detected and removed

The changes ensure better compatibility with the Server-Sent Events specification by:
- Maintaining data integrity when encountering invalid UTF-8 sequences
- Properly handling UTF-8 BOM markers which may be present at the start of SSE streams
- Preserving the original behavior for valid UTF-8 sequences

The implementation uses Swift's built-in `String(decoding:as:)` method to handle invalid sequences gracefully, making the parser more robust when dealing with potentially malformed input while still maintaining strict adherence to the SSE specification.
