### PR TITLE
Rename `EventSource.Error` to `EventSourceError`

### DIFF
--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -10,14 +10,14 @@ import Foundation
 /// (open upon initialization, auto-reconnect, close behavior).
 public actor EventSource {
     /// Errors that can occur when using `EventSource`.
-    public enum Error: Swift.Error, CustomStringConvertible {
+    public enum Error: Swift.Error, LocalizedError {
         /// The HTTP response status code is not 200.
         case invalidHTTPStatus(Int)
 
         /// The Content-Type header is not `text/event-stream`.
         case invalidContentType(String?)
 
-        public var description: String {
+        public var errorDescription: String {
             switch self {
             case .invalidHTTPStatus(let code):
                 return "Invalid HTTP response status code: \(code)"

--- a/Tests/EventSourceTests/IntegrationTests.swift
+++ b/Tests/EventSourceTests/IntegrationTests.swift
@@ -45,13 +45,13 @@ import Testing
 
         /// Actor to manage state in a thread-safe way
         actor ErrorTracker {
-            private var error: EventSource.Error?
+            private var error: EventSourceError?
 
-            func setError(_ newError: EventSource.Error?) {
+            func setError(_ newError: EventSourceError?) {
                 error = newError
             }
 
-            func getError() -> EventSource.Error? {
+            func getError() -> EventSourceError? {
                 return error
             }
         }
@@ -713,7 +713,7 @@ import Testing
                 // Set up error handler
                 let errorTracker = ErrorTracker()
                 eventSource.onError = { error in
-                    if let specificError = error as? EventSource.Error {
+                    if let specificError = error as? EventSourceError {
                         Task {
                             await errorTracker.setError(specificError)
                         }


### PR DESCRIPTION
Also conform to `LocalizedError` instead of `CustomStringConvertible`