### PR TITLE
Fix access control for `EventSource.Parser` APIs

### DIFF
--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -88,6 +88,9 @@ public actor EventSource {
         /// Track whether "data:" field was seen in the current event
         private var seenFields: Set<String> = []
 
+        /// Creates a new parser.
+        public init() {}
+
         private func fieldSeen(_ field: String) -> Bool {
             return seenFields.contains(field)
         }
@@ -217,22 +220,22 @@ public actor EventSource {
         }
 
         /// Get the next event from the queue
-        func getNextEvent() -> Event? {
+        public func getNextEvent() -> Event? {
             return eventQueue.isEmpty ? nil : eventQueue.removeFirst()
         }
 
         /// Get the last event ID (for reconnection)
-        func getLastEventId() -> String {
+        public func getLastEventId() -> String {
             return lastEventId
         }
 
         /// Get the reconnection time in milliseconds
-        func getReconnectionTime() -> Int {
+        public func getReconnectionTime() -> Int {
             return reconnectionTime
         }
 
         /// Complete parsing, handling any pending bytes
-        func finish() {
+        public func finish() {
             if sawCR {
                 let line = processLineBuffer()
                 handleLine(line)

--- a/Tests/EventSourceTests/AsyncEventsSequenceTests.swift
+++ b/Tests/EventSourceTests/AsyncEventsSequenceTests.swift
@@ -1,7 +1,6 @@
+import EventSource
 import Foundation
 import Testing
-
-@testable import EventSource
 
 @Suite("AsyncEventsSequence Tests", .timeLimit(.minutes(1)))
 struct AsyncEventsSequenceTests {
@@ -273,7 +272,7 @@ struct AsyncEventsSequenceTests {
         for try await event in byteSequence.events {
             events.append(event)
         }
-        
+
         // Verify we got all three events
         #expect(events.count == 3)
         #expect(events[0].data == "event1")

--- a/Tests/EventSourceTests/IntegrationTests.swift
+++ b/Tests/EventSourceTests/IntegrationTests.swift
@@ -1,7 +1,6 @@
+import EventSource
 import Foundation
 import Testing
-
-@testable import EventSource
 
 #if canImport(FoundationNetworking)
     import FoundationNetworking

--- a/Tests/EventSourceTests/ParserTests.swift
+++ b/Tests/EventSourceTests/ParserTests.swift
@@ -1,6 +1,5 @@
+import EventSource
 import Testing
-
-@testable import EventSource
 
 @Suite("EventSource Parser Tests", .timeLimit(.minutes(1)))
 struct ParserTests {


### PR DESCRIPTION
`@testable import` in tests obscured incorrect access level for APIs in `EventSource.Parser` intended to be made public. This PR fixes that, and adds missing public initializer.